### PR TITLE
decode error handler: strict -> replace

### DIFF
--- a/irclogger.py
+++ b/irclogger.py
@@ -156,6 +156,7 @@ class IRCLogger(irc.bot.SingleServerIRCBot):
             "dcc_disconnect", self._dcc_disconnect, -10)
 
         self.connection.buffer_class.encoding = encoding
+        self.connection.buffer_class.errors = "replace"
         self.connection.transmit_encoding = encoding
 
         self.api = API()


### PR DESCRIPTION
IRCからの発言のDecodeが失敗した時にそのまま落ちるのではなく、失敗する部分を�で置き換える処理に変更