### PR TITLE
change line breaks in message to spaces

### DIFF
--- a/irclogger.py
+++ b/irclogger.py
@@ -48,8 +48,9 @@ class ReactorWithEvent(irc.client.Reactor):
                 messages = incoming_messages_json
                 for m in messages:
                     if m:
+                        content = re.sub('\r\n|\n|\r', ' ', m["content"])
                         message = "[{0}] {1}".format(
-                            m["nickname"], m["content"])
+                            m["nickname"], content)
                         if m["command"] == "PRIVMSG":
                             self.connections[0].privmsg(
                                 m["channel"], message)


### PR DESCRIPTION
IRCに送信する内容中の改行をスペースに置換することで、改行がある場合にIRCに送信されないことを回避
fix #6