### PR TITLE
use killall

### DIFF
--- a/.github/workflows/ec2.yml
+++ b/.github/workflows/ec2.yml
@@ -20,6 +20,6 @@ jobs:
         env:
           EC2_URL: ${{ secrets.EC2_URL }}
         run: |
-          ssh ubuntu@$EC2_URL 'if [ `ps ux | grep irclogger.py | wc -l` = 2 ]; then kill `ps ux | grep irclogger.py -m1 | awk "{print \$2}"`; fi'
+          ssh ubuntu@$EC2_URL 'killall python3; echo "killall exit status: $?"'
           ssh ubuntu@$EC2_URL 'cd maobot-logger-ec2; git pull origin main; pip install -r requirements.txt'
           ssh ubuntu@$EC2_URL 'nohup python3 maobot-logger-ec2/irclogger.py </dev/null >maobot-info.log 2>&1 &'


### PR DESCRIPTION
`killall python3`を用いることで、PIDを不要とした。
また、loggerが既にkillされていたとしてもtestが止まらないように、echoでexit status表示させてワンライナー全体ではexit status 0とした。
fix #20 