### PR TITLE
fix class of MessageTooLong

### DIFF
--- a/irclogger.py
+++ b/irclogger.py
@@ -66,7 +66,7 @@ class ReactorWithEvent(irc.client.Reactor):
             elif command == "NOTICE":
                 self.connections[0].notice(
                     channel, message)
-        except MessageTooLong:
+        except irc.client.MessageTooLong:
             message1 = message[:len(message)//2]
             message2 = message[len(message)//2:]
             self.post_IRC(command, channel, message1)


### PR DESCRIPTION
MessageTooLongはirc.clientにあることを失念していたため修正
(ちなみにReviewerには自分自身を選べないようです)